### PR TITLE
Adds distroless OpenJDK with Payara Micro 5.2021.7

### DIFF
--- a/java11-5.2021.7/Dockerfile
+++ b/java11-5.2021.7/Dockerfile
@@ -1,0 +1,25 @@
+FROM payara/micro:5.2021.7 as build
+
+FROM gcr.io/distroless/java:11
+LABEL maintainer="qaware-oss@qaware.de"
+
+ENV PAYARA_PATH /opt/payara
+ENV DEPLOY_DIR $PAYARA_PATH/deployments
+ENV AUTODEPLOY_DIR $PAYARA_PATH/deployments
+
+COPY --from=amd64/busybox:1.31.1 /bin/busybox /busybox/busybox
+RUN ["/busybox/busybox", "--install", "/bin"]
+
+COPY --from=build /etc/passwd /etc/passwd
+COPY --from=build /etc/group /etc/group
+
+COPY --from=build $PAYARA_PATH $PAYARA_PATH
+
+USER payara
+WORKDIR $PAYARA_PATH
+
+# Default payara ports to expose
+EXPOSE 8080 8443 6900
+
+ENTRYPOINT ["java", "-server", "-Xshare:auto", "-XX:+UseContainerSupport", "-XX:MaxRAMPercentage=60.0", "-XX:ThreadStackSize=256", "-XX:MaxMetaspaceSize=128m", "-XX:+UseShenandoahGC", "-XX:+AlwaysPreTouch", "-XX:+UseNUMA", "-XX:+UseStringDeduplication", "-jar", "/opt/payara/payara-micro.jar"]
+CMD ["--nocluster", "--disablephonehome", "--deploymentDir", "/opt/payara/deployments"]

--- a/java11-5.2021.7/Makefile
+++ b/java11-5.2021.7/Makefile
@@ -1,0 +1,13 @@
+PAYARA_VERSION=5
+PAYARA_RELEASE=2021.7
+PAYARA_TAG=${PAYARA_VERSION}.${PAYARA_RELEASE}
+
+image:
+	docker build -t distroless-java-payara-micro:java11-${PAYARA_TAG} .
+	@echo ""
+	@echo "To test the image run:"
+	@echo "docker run -it --rm --cpus 2 --memory 640m distroless-java-payara-micro:java11-${PAYARA_TAG}"
+
+tag-and-push: image
+	docker tag distroless-java-payara-micro:java11-${PAYARA_TAG} qaware/distroless-java-payara-micro:java11-${PAYARA_TAG}
+	docker push qaware/distroless-java-payara-micro:java11-${PAYARA_TAG}


### PR DESCRIPTION
Use latest distroless OpenJDK with Payara Micro 5.2021.7.
Performed some JVM tunings, use low latency GC.
Build and pushed image.